### PR TITLE
Only show calculate binding attribute if it is defined and not empty

### DIFF
--- a/public/javascripts/data.js
+++ b/public/javascripts/data.js
@@ -420,7 +420,7 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
         if (control.constraint !== '')
             constraint.push(control.constraint);
         // advanced calculate
-        if (control.calculate !== '')
+        if (control.calculate !== undefined && control.calculate !== '')
             binding.attrs.calculate = control.calculate;
 
         if (relevance.length > 0)


### PR DESCRIPTION
This is a problem you only see on some forms (presumably saved forms before calculate was changed to a simple field [1]).  If you need an example of a such a bad form, look at `form id = build_CHILDREN-6-59-MONTHS-ANTHROPOMETRY-HEALTH-AND-ANAEMIA_1356711384` or email me for a copy.

This patch checks to make sure that calculate is not undefined. Might also need to check to make sure the string length is > 0. I'll leave that to you...

[1] = https://github.com/clint-tseng/odkbuild/commit/dc28193b3750b3bbb7a90e3398a4dd5fad141dd9
