### PR TITLE
Hotfix: Cleaner metadata nodes, put value text with output tag on single line

### DIFF
--- a/public/javascripts/data.js
+++ b/public/javascripts/data.js
@@ -123,7 +123,7 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
                 {
                     if (match.index > 0)
                     {
-                        result.push(itext.slice(0, match.index).trim());
+                        result.push(itext.slice(0, match.index));
                         itext = itext.slice(match.index);
                     }
 
@@ -136,7 +136,7 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
                     itext = itext.slice(match[0].length);
                 }
                 if (itext.length > 0)
-                    result.push(itext.trim());
+                    result.push(itext);
 
                 if (result.length === 0)
                     result = obj[translation.attrs.lang];
@@ -560,10 +560,24 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
         else if (obj.children !== undefined)
         {
             result += '>\n';
-            _.each(obj.children, function(child)
+            // if value text has an array of children, place on single line
+            if (obj.name == 'value' && obj.children.length > 1) 
             {
-                result += JSONtoXML(child, indentLevel + 1);
-            });
+                var valueText = generateIndent(indentLevel + 1);
+                _.each(obj.children, function(child)
+                {
+                    valueText += JSONtoXML(child);
+                });
+                result += valueText.replace(/\n/gm,'') + '\n';
+            } 
+            else 
+            {
+                _.each(obj.children, function(child)
+                {
+                    result += JSONtoXML(child, indentLevel + 1);
+                });
+            }
+            
             result += generateIndent(indentLevel) + '</' + obj.name + '>\n';
         }
         else


### PR DESCRIPTION
d29d65d Makes empty metadata nodes cleaner. Instead of `<timeStart></timeStart>`, it's`<timeStart/>`.

4144bb1 Is as clean of a solution as I could think of. To make sure I don't add or remove whitespaces, trim() has been removed from the building of the model.
