### PR TITLE
update link to fix #250

### DIFF
--- a/server/views/index.erb
+++ b/server/views/index.erb
@@ -195,7 +195,7 @@
         </form>
       </div>
       <div class="offlineNotice">
-        Tired of logging in? Did you know there is a <a href="https://getodk.org/software/#odk-build" rel="external">downloadable version of ODK Build available?</a> Simply save your forms to file from here using the File menu and you can open them there.
+        Tired of logging in? Did you know there is a <a href="https://github.com/getodk/build/releases/latest" rel="external">downloadable version of ODK Build available?</a> Simply save your forms to file from here using the File menu and you can open them there.
       </div>
       <div class="modalButtonContainer">
         <a class="modalButton signinLink" href="#signin">Sign in</a>


### PR DESCRIPTION
updates link to match what is used in the [docs](https://docs.getodk.org/build-intro/#using-odk-build), and gets you to a page that has the download on it instead of just redirecting to the Get ODK homepage