### PR TITLE
noop: Bump version

### DIFF
--- a/server/views/index.erb
+++ b/server/views/index.erb
@@ -408,7 +408,7 @@
       <h3>About</h3>
       <div class="modalContents">
         <p>
-          ODK Build is a form builder for <a href="https://getodk.org/" rel="external">ODK</a>. You are using v<a href="https://github.com/getodk/build/releases/tag/0.4.0" rel="external">0.4.0</a>.
+          ODK Build is a form builder for <a href="https://getodk.org/" rel="external">ODK</a>. You are using v<a href="https://github.com/getodk/build/releases/tag/0.4.1" rel="external">0.4.1</a>.
         </p>
         <p>
           Build was created by Issa Tseng in Seattle, Bangalore, Pittsburgh, and 40,000 feet in the air.


### PR DESCRIPTION
Just bump the version to 0.4.1. This PR should be merged if we want to deploy to test after Milestone 0.4.1 issues have been merged.

We could wait with the version bump until all current PRs are merged.