### PR TITLE
noop: Add in-app messaging about contributing

### DIFF
--- a/server/views/index.erb
+++ b/server/views/index.erb
@@ -417,6 +417,10 @@
           Need help?
           <a href="http://forum.getodk.org/" rel="external">Ask on the forum</a>.
         </p>
+        <p>
+          Want to help?
+          <a href="https://github.com/getodk/build/blob/master/CONTRIBUTING.md" rel="external">Become a contributor</a>!
+        </p>
       </div>
       <div class="modalButtonContainer">
         <a class="modalButton jqmClose" href="#close">Done</a>


### PR DESCRIPTION
Close #82 

Adds a message to the "About" menu:
![image](https://user-images.githubusercontent.com/762815/151280978-e07896e2-3918-4a6d-bcb7-810f46355b14.png)
