### PR TITLE
new: support autosend and autodelete

### DIFF
--- a/public/javascripts/data.js
+++ b/public/javascripts/data.js
@@ -49,7 +49,9 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
                 htitle: htitle,
                 instance_name: $('#formProperties_instanceName').val(),
                 public_key: $('#formProperties_publicKey').val(),
-                submission_url: $('#formProperties_submissionUrl').val()
+                submission_url: $('#formProperties_submissionUrl').val(),
+                auto_send: $('#formProperties_autosend').find(":selected").val(),
+                auto_delete: $('#formProperties_autodelete').find(":selected").val()
             }
         };
     };
@@ -123,6 +125,8 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
         $('#formProperties_instanceName').val(formObj.metadata.instance_name);
         $('#formProperties_publicKey').val(formObj.metadata.public_key);
         $('#formProperties_submissionUrl').val(formObj.metadata.submission_url);
+        $('#formProperties_autosend').val(formObj.metadata.auto_send);
+        $('#formProperties_autodelete').val(formObj.metadata.auto_delete);
         odkmaker.i18n.setActiveLanguages(formObj.metadata.activeLanguages);
         odkmaker.options.presets = formObj.metadata.optionsPresets;
         loadMany($('.workspace'), formObj.controls);
@@ -880,6 +884,7 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
                 'xmlns:xsd': 'http://www.w3.org/2001/XMLSchema',
                 'xmlns:jr': 'http://openrosa.org/javarosa',
                 'xmlns:ev': 'http://www.w3.org/2001/xml-events',
+                'xmlns:orx': 'http://openrosa.org/xforms',
                 'xmlns:odk': 'http://www.opendatakit.org/xforms'
             },
             children: [
@@ -927,7 +932,10 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
             } });
         }
 
-        if (!$.isBlank(internal.metadata.public_key) || !$.isBlank(internal.metadata.submission_url))
+        if (!$.isBlank(internal.metadata.public_key) ||          
+            !$.isBlank(internal.metadata.submission_url) ||
+            internal.metadata.auto_send !== "default" ||
+            internal.metadata.auto_delete !== "default")
         {
             var submission = {
                 name: 'submission',
@@ -942,6 +950,12 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
 
             if (!$.isBlank(internal.metadata.submission_url))
                 submission.attrs.action = internal.metadata.submission_url;
+
+            if (internal.metadata.auto_send !== "default")
+                submission.attrs["orx:auto-send"] = internal.metadata.auto_send;
+
+            if (internal.metadata.auto_delete !== "default")
+                submission.attrs["orx:auto-delete"] = internal.metadata.auto_delete;
         }
 
         _.each(internal.controls, function(control)

--- a/public/stylesheets/styles.css
+++ b/public/stylesheets/styles.css
@@ -177,7 +177,8 @@ form label
     line-height: 25px;
     margin-bottom: -25px;
 }
-form input
+form input,
+form select
 {
     margin-bottom: 0.5em;
     margin-left: 7em;
@@ -1462,7 +1463,8 @@ body > .control.last .controlFlowArrow,
     width: 40em;
 }
 
-.formPropertiesDialog input
+.formPropertiesDialog input,
+.formPropertiesDialog select
 {
     margin-left: 10em;
     width: calc(100% - 10em);

--- a/server/views/index.erb
+++ b/server/views/index.erb
@@ -316,6 +316,22 @@
           <label for="formProperties_submissionUrl">Submission URL</label>
           <input type="text" id="formProperties_submissionUrl" name="submissionUrl" />
           <p>Directs your submissions somewhere other than the Aggregate that supplied the form. This is the ODK Aggregate website url with <code>Aggregate.html</code> replaced by <code>submission</code>.</p>
+          
+          <label for="formProperties_autosend">Auto-send</label>
+          <select id="formProperties_autosend" name="autosend">
+            <option value="default">Follow ODK Collect settings</option>
+            <option value="true">Always</option>
+            <option value="false">Never</option>
+          </select>
+          <p>Override or follow the ODK Collect form management setting "Auto send".</p>
+
+          <label for="formProperties_autodelete">Auto-delete</label>
+          <select id="formProperties_autodelete" name="autodelete">
+            <option value="default">Follow ODK Collect settings</option>
+            <option value="true">Always</option>
+            <option value="false">Never</option>
+          </select>
+          <p>Override or follow the ODK Collect form management setting "Delete after send".</p>
         </form>
       </div>
       <div class="modalButtonContainer">


### PR DESCRIPTION
Add support to optionally override Collect's autosend and autodelete form management settings.

* Closes #165 
* Form properties (index.erb): add two dropdowns for each setting - empty on legacy forms, three options default, always, never.
* The dropdowns are styled like the other form properties elements (styles.css).
* The form data is plumbed through `data.js` to end up as a child node in the model, tacking onto what `submission_url` does.
* Screenshot 1:  with options always and never, respectively
![image](https://user-images.githubusercontent.com/762815/151469556-ca4b7627-8a2d-4a6c-ba00-35b3eb54af02.png)
* Screenshot 2: with option "default" = "Follow ODK Collect settings"
![image](https://user-images.githubusercontent.com/762815/151469583-32067437-0e33-4749-9c95-3c68133cf13f.png)
* When loading a new form from "My forms", autosend and autodelete are loaded from that form.
* When exporting to XML with autosend always, autodelete never:
  * New namespace `orx`
  * New model child `<submission method="form-data-post" orx:auto-send="true" orx:auto-delete="false"/>`
```
<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:orx="http://openrosa.org/xforms" xmlns:odk="http://www.opendatakit.org/xforms">
  <h:head>
    <h:title>Untitled Form</h:title>
    <model>
      <instance>
        <data id="Untitled-Form" version="1643332534">
          <meta>
            <instanceID/>
          </meta>
          <untitled2/>
        </data>
      </instance>
      <itext>
        <translation lang="English">
          <text id="/data/untitled2:label">
            <value>test</value>
          </text>
        </translation>
      </itext>
      <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" jr:preload="uid"/>
      <submission method="form-data-post" orx:auto-send="true" orx:auto-delete="false"/>
      <bind nodeset="/data/untitled2" type="string"/>
    </model>
  </h:head>
  <h:body>
    <input ref="/data/untitled2">
      <label ref="jr:itext('/data/untitled2:label')"/>
    </input>
  </h:body>
</h:html>
```
* With both settings to "default" (follow Collect), no submission method node is inserted.
* With only one setting to non-default (e.g. autosend always, autodelete default), only the non-default is exported:
```
      <submission method="form-data-post" orx:auto-send="true"/>
```
* Export to XLSForm does not break, but also silently drops the autosend/autodelete settings.
* Once this PR is merged, I'll send a PR for metadata kinds email and audit to conclude the rework of #266.

