### PR TITLE
new: metadata kind email and new control for Audit

### DIFF
--- a/public/javascripts/control.js
+++ b/public/javascripts/control.js
@@ -33,7 +33,7 @@
             // add our hero's properties
             _.each(properties, function(property, name)
             {
-                if (name === 'metadata') return;
+                if (name === 'metadata' || name === 'audit') return;
 
                 $('<li class="propertyItem"/>')
                     .propertyEditor(property, name, $this)
@@ -91,6 +91,10 @@
         else if (type == 'metadata')
         {
             $headline.children('.controlLabel').text(properties.kind.value);
+        }
+        else if (type == 'audit')
+        {
+            $headline.children('.controlLabel').text("Audit");
         }
         else
         {
@@ -333,7 +337,7 @@
 
             if (defaultProperties != null)
                 properties = defaultProperties;
-            else if ((type == 'group') || (type == 'branch') || (type == 'metadata'))
+            else if ((type == 'group') || (type == 'branch') || (type == 'metadata') || (type == 'audit'))
                 properties = $.extend(true, {}, $.fn.odkControl.controlProperties[type]);
             else
             {
@@ -836,56 +840,62 @@
           kind:       { name: 'Kind',
                         type: 'enum',
                         description: 'Type of metadata to add.',
-                        options: [ 'Device ID', 'Start Time', 'End Time', 'Today', 'Username', 'Email', 'Subscriber ID', 'SIM Serial', 'Phone Number', 'Start Geopoint', 'Audit' ],
+                        options: [ 'Device ID', 'Start Time', 'End Time', 'Today', 'Username', 'Email', 'Subscriber ID', 'SIM Serial', 'Phone Number', 'Start Geopoint' ],
                         value: 'Device ID',
                         summary: true },
-          location_priority: {
-                        name: 'Audit Location Priority',
-                        type: 'enum',
-                        description: 'This setting balances location accuracy with battery life.',
-                        tips: [
-                            'See <a href="https://developers.google.com/android/reference/com/google/android/gms/location/LocationRequest" ' +
-                            'target="_" rel="nofollow">the LocationRequest documentation</a> for an explanation of the options. ' +
-                            'Using "balanced" will capture the location at least at specified intervals while preserving power.' +
-                            'Using "off" will disable location audit altogether.'],
-                        options: ['off', 'no-power', 'low-power', 'balanced', 'high-accuracy'],
-                        value: 'balanced',
-                        advanced: true,
-                        summary: false },
-          location_min_interval: {
-                        name: 'Audit Location Minimum Interval',
-                        type: 'text',
-                        description: 'This setting governs how often location is captured for the audit log.',
-                        tips: [
-                            'The desired minimum time, in seconds, location updates will be fetched. ' +
-                            'Required to enable location in audit log. To disable location audit, select "off" in the priority.' +
-                            'Default: 20 seconds.'
-                        ],
-                        value: '20',
-                        advanced: true,
-                        summary: false },
-          location_max_age: {
-                        name: 'Audit Location Maximum Age',
-                        type: 'text',
-                        description: 'The maximum time, in seconds, locations will be considered valid.',
-                        tips: [
-                            'Must be greater than or equal to the minimum interval. ' +
-                            'Required to enable location in audit log. To disable location audit, select "off" in the priority.' +
-                            'Default: 60 seconds (1 minute).'
-                        ],
-                        value: '60',
-                        advanced: true,
-                        summary: false },
-          track_changes: {
-                        name: 'Audit Track Changes',
-                        type: 'enum',
-                        description: 'Whether to track changes to the form made any time before submission.',
-                        tips: [],
-                        options: ['true', 'false'],
-                        value: 'true',
-                        advanced: true,
-                        summary: false },
         },
+        audit: {
+            name:       { name: 'Data Name',
+                          type: 'text',
+                          description: 'The name of the column in the exported data.',
+                          tips: [ 'Must start with a letter, and may only include letters, numbers, hyphens, underscores, and periods.' ],
+                          validation: [ 'required', 'xmlLegalChars', 'unique' ],
+                          required: true,
+                          value: 'audit',
+                          summary: false },
+            location_priority: {
+                          name: 'Location Priority',
+                          type: 'enum',
+                          description: 'This setting balances location accuracy with battery life.',
+                          tips: [
+                              'See <a href="https://developers.google.com/android/reference/com/google/android/gms/location/LocationRequest" ' +
+                              'target="_" rel="nofollow">the LocationRequest documentation</a> for an explanation of the options. ' +
+                              'Using "balanced" will capture the location at least at specified intervals while preserving power.' +
+                              'Using "off" will disable location audit altogether.'],
+                          options: ['off', 'no-power', 'low-power', 'balanced', 'high-accuracy'],
+                          value: 'balanced',
+                          summary: false },
+            location_min_interval: {
+                          name: 'Location Minimum Interval',
+                          type: 'text',
+                          description: 'This setting governs how often location is captured for the audit log.',
+                          tips: [
+                              'The desired minimum time, in seconds, location updates will be fetched. ' +
+                              'Required to enable location in audit log. To disable location audit, select "off" in the priority.' +
+                              'Default: 20 seconds.'
+                          ],
+                          value: '20',
+                          summary: false },
+            location_max_age: {
+                          name: 'Location Maximum Age',
+                          type: 'text',
+                          description: 'The maximum time, in seconds, locations will be considered valid.',
+                          tips: [
+                              'Must be greater than or equal to the minimum interval. ' +
+                              'Required to enable location in audit log. To disable location audit, select "off" in the priority.' +
+                              'Default: 60 seconds (1 minute).'
+                          ],
+                          value: '60',
+                          summary: false },
+            track_changes: {
+                          name: 'Track Changes',
+                          type: 'enum',
+                          description: 'Whether to track changes to the form made any time before submission.',
+                          tips: [],
+                          options: ['true', 'false'],
+                          value: 'true',
+                          summary: false },
+          },
     };
 
     // TODO: combine this and the above hash into one when all these declarations move out into an impl file.
@@ -965,8 +975,11 @@
         },
         metadata: {
             name: 'Metadata',
-            description: 'Metadata questions silently and automatically collect information about the session. ' +
-            'Audit has additional advanced options.',
+            description: 'Metadata questions silently and automatically collect information about the session. '
+        },
+        audit: {
+            name: 'Audit',
+            description: 'Audit metadata can track form changes and/or device location.',
         }
     };
 

--- a/public/javascripts/control.js
+++ b/public/javascripts/control.js
@@ -860,7 +860,7 @@
                           tips: [
                               'See <a href="https://developers.google.com/android/reference/com/google/android/gms/location/LocationRequest" ' +
                               'target="_" rel="nofollow">the LocationRequest documentation</a> for an explanation of the options. ' +
-                              'Using "balanced" will capture the location at least at specified intervals while preserving power.' +
+                              'Using "balanced" will capture the location at least at specified intervals while preserving power. ' +
                               'Using "off" will disable location audit altogether.'],
                           options: ['off', 'no-power', 'low-power', 'balanced', 'high-accuracy'],
                           value: 'balanced',
@@ -882,7 +882,7 @@
                           description: 'The maximum time, in seconds, locations will be considered valid.',
                           tips: [
                               'Must be greater than or equal to the minimum interval. ' +
-                              'Required to enable location in audit log. To disable location audit, select "off" in the priority.' +
+                              'Required to enable location in audit log. To disable location audit, select "off" in the priority. ' +
                               'Default: 60 seconds (1 minute).'
                           ],
                           value: '60',

--- a/public/javascripts/control.js
+++ b/public/javascripts/control.js
@@ -578,6 +578,7 @@
     };
 
     // Property fields per control type
+    // Nb data.js / loadOne has custom logic to exclude some properties for metadata kind "audit".
     $.fn.odkControl.controlProperties = {
         inputText: {
           length:     { name: 'Length',
@@ -836,9 +837,56 @@
           kind:       { name: 'Kind',
                         type: 'enum',
                         description: 'Type of metadata to add.',
-                        options: [ 'Device ID', 'Start Time', 'End Time', 'Today', 'Username', 'Subscriber ID', 'SIM Serial', 'Phone Number', 'Start Geopoint' ],
+                        options: [ 'Device ID', 'Start Time', 'End Time', 'Today', 'Username', 'Email', 'Subscriber ID', 'SIM Serial', 'Phone Number', 'Start Geopoint', 'Audit' ],
                         value: 'Device ID',
-                        summary: true } },
+                        summary: true },
+          location_priority: {
+                        name: 'Audit Location Priority',
+                        type: 'enum',
+                        description: 'This setting balances location accuracy with battery life.',
+                        tips: [
+                            'See <a href="https://developers.google.com/android/reference/com/google/android/gms/location/LocationRequest" ' +
+                            'target="_" rel="nofollow">the LocationRequest documentation</a> for an explanation of the options. ' +
+                            'Using "balanced" will capture the location at least at specified intervals while preserving power.' +
+                            'Using "off" will disable location audit altogether.'],
+                        options: ['off', 'no-power', 'low-power', 'balanced', 'high-accuracy'],
+                        value: 'balanced',
+                        advanced: true,
+                        summary: false },
+          location_min_interval: {
+                        name: 'Audit Location Minimum Interval',
+                        type: 'text',
+                        description: 'This setting governs how often location is captured for the audit log.',
+                        tips: [
+                            'The desired minimum time, in seconds, location updates will be fetched. ' +
+                            'Required to enable location in audit log. To disable location audit, select "off" in the priority.' +
+                            'Default: 20 seconds.'
+                        ],
+                        value: '20',
+                        advanced: true,
+                        summary: false },
+          location_max_age: {
+                        name: 'Audit Location Maximum Age',
+                        type: 'text',
+                        description: 'The maximum time, in seconds, locations will be considered valid.',
+                        tips: [
+                            'Must be greater than or equal to the minimum interval. ' +
+                            'Required to enable location in audit log. To disable location audit, select "off" in the priority.' +
+                            'Default: 60 seconds (1 minute).'
+                        ],
+                        value: '60',
+                        advanced: true,
+                        summary: false },
+          track_changes: {
+                        name: 'Audit Track Changes',
+                        type: 'enum',
+                        description: 'Whether to track changes to the form made any time before submission.',
+                        tips: [],
+                        options: ['true', 'false'],
+                        value: 'true',
+                        advanced: true,
+                        summary: false },
+        },
     };
 
     // TODO: combine this and the above hash into one when all these declarations move out into an impl file.
@@ -918,7 +966,8 @@
         },
         metadata: {
             name: 'Metadata',
-            description: 'Metadata questions silently and automatically collect information about the session.',
+            description: 'Metadata questions silently and automatically collect information about the session. ' +
+            'Audit has additional advanced options.',
         }
     };
 

--- a/public/javascripts/control.js
+++ b/public/javascripts/control.js
@@ -848,7 +848,7 @@
             name:       { name: 'Data Name',
                           type: 'text',
                           description: 'The name of the column in the exported data.',
-                          tips: [ 'Must start with a letter, and may only include letters, numbers, hyphens, underscores, and periods.' ],
+                          tips: [ 'Must be "audit".' ],
                           validation: [ 'required', 'xmlLegalChars', 'unique' ],
                           required: true,
                           value: 'audit',
@@ -979,7 +979,7 @@
         },
         audit: {
             name: 'Audit',
-            description: 'Audit metadata can track form changes and/or device location.',
+            description: 'Audit can track form changes and/or device location.',
         }
     };
 

--- a/public/javascripts/control.js
+++ b/public/javascripts/control.js
@@ -578,7 +578,6 @@
     };
 
     // Property fields per control type
-    // Nb data.js / loadOne has custom logic to exclude some properties for metadata kind "audit".
     $.fn.odkControl.controlProperties = {
         inputText: {
           length:     { name: 'Length',

--- a/public/javascripts/data.js
+++ b/public/javascripts/data.js
@@ -74,14 +74,14 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
     var loadOne = odkmaker.data.loadOne = function(control, $parent)
     {
         var properties = null;
-        if ((control.type == 'group') || (control.type == 'branch') || (control.type == 'metadata'))
+        if ((control.type == 'group') || (control.type == 'branch') || (control.type == 'metadata') || (control.type == 'audit'))
             properties = $.extend(true, {}, $.fn.odkControl.controlProperties[control.type]);
         else
             properties = $.extend(true, $.extend(true, {}, $.fn.odkControl.defaultProperties),
                                         $.fn.odkControl.controlProperties[control.type]);
         _.each(properties, function(property, key)
         {
-            if (key === 'metadata') return;
+            if (key === 'metadata' || key === 'audit') return;
             property.value = control[key];
         });
         properties.metadata = control.metadata;
@@ -441,8 +441,8 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
             return;
         }
 
-         // control type metadata of kind "Audit"
-         if (control.type == 'metadata' && control.kind == 'Audit') {
+         // control type "Audit"
+         if (control.type == 'audit') {
 
             /* Add the `orx:audit` element to the `orx:meta` element.
              * 
@@ -458,7 +458,7 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
             if (instance.children[0].name == 'orx:meta') {
                 instance.children[0].children.push({ name: 'orx:audit' });
             } else {
-                console.log("No 'orx:meta' element found in instance. Adding audit metadata will likely fail.");
+                console.log("No 'orx:meta' element found in instance. Adding audit will likely fail.");
             }
 
             /* Add binding node with parameters 
@@ -500,8 +500,8 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
             return;
         }
 
-        // control type metadata of other kinds
-        if (control.type == 'metadata' && control.kind != 'Audit')
+        // control type metadata
+        if (control.type == 'metadata')
         {
             // instance
             var instanceTag = {

--- a/public/javascripts/data.js
+++ b/public/javascripts/data.js
@@ -64,38 +64,18 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
     };
 
     /**
-     * Load a single control's properties into the sidebar.
+     * Load a single control's properties into the sidebar on form load.
      * 
-     * Each time a control is clicked in the main area, this function populates the 
+     * Each time a form is loaded, this function populates the 
      * "properties" sidebar with the control's properties as defined in 
      * `$.fn.odkControl.controlProperties` (`control.js`).
      * 
-     * In general, all properties are loaded into the sidebar as per `control.js`.
-     * Properties which are only relevant to some control types, such as 
-     * Audit's `location_priority`, `location_min_interval`, `location_max_age`, and
-     * `track_changes` are prevented here from entering the sidebar.
-     * 
-     * The exact removal of properties is hard-coded here, since this behaviour is
-     * a one-off for metadata kind "audit". Should more properties
-     * need fine-tuning, additional keys can be added to `$.fn.odkControl.controlProperties`
-     * and `loadOne` can be refactored to a more generic "include if xxx" behaviour.
      */
     var loadOne = odkmaker.data.loadOne = function(control, $parent)
     {
         var properties = null;
         if ((control.type == 'group') || (control.type == 'branch') || (control.type == 'metadata'))
-        {    
-            var controlProps = $.fn.odkControl.controlProperties[control.type];
-            // Custom exclusion of audit properties for other metadata kinds
-            if ((control.type == 'metadata') && (control.kind != 'Audit'))
-            {
-                delete controlProps.location_priority;
-                delete controlProps.location_min_interval;
-                delete controlProps.location_max_age;
-                delete controlProps.track_changes;
-            }
-            properties = $.extend(true, {}, controlProps);
-        }
+            properties = $.extend(true, {}, $.fn.odkControl.controlProperties[control.type]);
         else
             properties = $.extend(true, $.extend(true, {}, $.fn.odkControl.defaultProperties),
                                         $.fn.odkControl.controlProperties[control.type]);

--- a/public/javascripts/data.js
+++ b/public/javascripts/data.js
@@ -444,32 +444,36 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
          // control type "Audit"
          if (control.type == 'audit') {
 
-            /* Add the `orx:audit` element to the `orx:meta` element.
+            /* Add the `audit` element to the `meta` element.
              * 
-             * TODO: explicitly select the element by its name 'orx:meta'
+             * The namespace prefix `orx:` is omitted because it could break existing forms
+             * on ODK Central with a non-prefixed meta node.
              * 
-             * Discuss: why are other supported meta elements not added to `orx:meta`?
+             * Explicitly selecting the element by its name 'meta' would be an improvement.
+             * 
+             * Discuss: why are other supported meta elements not added to `meta`?
              * https://getodk.github.io/xforms-spec/#metadata
              * 
              * The first three attributes are required for location audit.
              * location_priority == "off" disables location audit and excludes all three location audit fields.
              */
 
-            if (instance.children[0].name == 'orx:meta') {
-                instance.children[0].children.push({ name: 'orx:audit' });
+            if (instance.children[0].name == 'meta') {
+                instance.children[0].children.push({ name: 'audit' });
             } else {
-                console.log("No 'orx:meta' element found in instance. Adding audit will likely fail.");
+                console.log("No 'meta' element found in instance. Adding audit will likely fail.");
             }
 
             /* Add binding node with parameters 
              * 
              * Special path: /data/meta/audit
+             * The data name 'audit' must not be changed, therefore it is not configurable.
              * Conditional logic to drop location audit fields if location_priority == "off"
              */
             var binding = {
                 name: 'bind',
                 attrs: {
-                    'nodeset': xpath + 'meta/' + control.name,
+                    'nodeset': xpath + 'meta/audit',
                     type: 'binary'
                 }
             };
@@ -917,7 +921,7 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
 
         // Per OpenRosa spec, instanceID should be in /data/meta
         var meta = {
-            name: 'orx:meta',
+            name: 'meta',
             children: [ { name: 'orx:instanceID' } ]
         };
 

--- a/server/views/index.erb
+++ b/server/views/index.erb
@@ -123,6 +123,7 @@
           <li><a class="toolButton inputSelectMany" rel="inputSelectMany">Select Multiple</a></li>
           <li class="separator"></li>
           <li><a class="toolButton metadata" rel="metadata">Metadata</a></li>
+          <li><a class="toolButton audit" rel="audit">Audit</a></li>
           <li class="separator"></li>
           <li><a class="toolButton group" rel="group">Group</a></li>
         </ul>


### PR DESCRIPTION
This PR brings the two final new features of frankenPR #266 (fixes #266) and fixes #164 and fixes #209.

In a small addition, the last missing metadata kind "email" is added in two places:
* 1/2: email is added to the list of available metadata kinds,
* 2/2: email is added to the XML in the same way as e.g. username.
I've included this here as the code changes are closely related for review to require the same brainspace.

The main part of the PR is to support audit, which is different to the other metadata fields as it has its own [four attributes](https://getodk.github.io/xforms-spec/#audit-attributes), but always has the label "Audit" (so that can be made implicit).
Audit is added as a top level control element. Much of the handling is similar to metadata (there, some `if` clauses get extended to include the control type `audit`), some is different enough to warrant its own code block. I'll annotate the code changes with what the sections do.

## Walkthrough
Let's build a simple form to show the new behaviour of email and audit.
One text field:
![image](https://user-images.githubusercontent.com/762815/151741508-f460b9eb-1dc3-4c3b-870a-cc92953cfc1e.png)

The required namespace `orx` was already added in #281.
We now see the meta node being prefixed as `orx:meta` as per the [XForms metadata spec](https://getodk.github.io/xforms-spec/#metadata).

```
<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:orx="http://openrosa.org/xforms" xmlns:odk="http://www.opendatakit.org/xforms">
  <h:head>
    <h:title>164 Audit Email</h:title>
    <model>
      <instance>
        <data id="164-Audit-Email" orx:version="1643605416">
          <orx:meta>
            <orx:instanceID/>
          </orx:meta>
          <text1/>
        </data>
      </instance>
      <itext>
        <translation lang="English">
          <text id="/data/text1:label">
            <value>Text 1 label</value>
          </text>
          <text id="/data/text1:hint">
            <value>Text 1 hint</value>
          </text>
        </translation>
      </itext>
      <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" jr:preload="uid"/>
      <bind nodeset="/data/text1" type="string"/>
    </model>
  </h:head>
  <h:body>
    <input ref="/data/text1">
      <label ref="jr:itext('/data/text1:label')"/>
      <hint ref="jr:itext('/data/text1:hint')"/>
    </input>
  </h:body>
</h:html>
```

Adding existing metadata `username` and new metadata `email`, we see that email behaves exactly like username:
![image](https://user-images.githubusercontent.com/762815/151741950-3b33cb48-ae32-477f-b5cf-27e7659724a1.png)

```
      <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" jr:preload="uid"/>
      <bind nodeset="/data/text1" type="string"/>
      <bind nodeset="/data/username" type="string" jr:preload="property" jr:preloadParams="username"/>
      <bind nodeset="/data/email" type="string" jr:preload="property" jr:preloadParams="email"/>
```

Adding a new control "Audit" shows the audit attributes as first level properties, populated with defaults, and the control being labelled as "Audit". The data name also defaults to "audit" but can be adjusted.
![image](https://user-images.githubusercontent.com/762815/151742090-18628a12-f509-4a7e-8ead-7dbd05fc6138.png)
The XML output now reads:
```
<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:orx="http://openrosa.org/xforms" xmlns:odk="http://www.opendatakit.org/xforms">
  <h:head>
    <h:title>164 Audit Email</h:title>
    <model>
      <instance>
        <data id="164-Audit-Email" orx:version="1643605882">
          <orx:meta>
            <orx:instanceID/>
            <orx:audit/>
          </orx:meta>
          <text1/>
          <username/>
          <email/>
        </data>
      </instance>
      <itext>
        <translation lang="English">
          <text id="/data/text1:label">
            <value>Text 1 label</value>
          </text>
          <text id="/data/text1:hint">
            <value>Text 1 hint</value>
          </text>
        </translation>
      </itext>
      <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" jr:preload="uid"/>
      <bind nodeset="/data/text1" type="string"/>
      <bind nodeset="/data/username" type="string" jr:preload="property" jr:preloadParams="username"/>
      <bind nodeset="/data/email" type="string" jr:preload="property" jr:preloadParams="email"/>
      <bind nodeset="/data/meta/audit" type="binary" odk:location-priority="balanced" odk:location-min-interval="20" odk:location-max-age="60" odk:track-changes="true"/>
    </model>
  </h:head>
  <h:body>
    <input ref="/data/text1">
      <label ref="jr:itext('/data/text1:label')"/>
      <hint ref="jr:itext('/data/text1:hint')"/>
    </input>
  </h:body>
</h:html>
```

Changing the audit parameter `location priority` to "off" creates the bind node 
```
<bind nodeset="/data/meta/audit" type="binary" odk:track-changes="true"/>
```

Changing the audit parameter `track changes` to "false" creates the bind node
```
      <bind nodeset="/data/meta/audit" type="binary" odk:track-changes="false"/>
```
which obviously makes sense only if combined with location tracking enabled (prio other than "off"), e.g.
```
      <bind nodeset="/data/meta/audit" type="binary" odk:location-priority="high-accuracy" odk:location-min-interval="20" odk:location-max-age="60" odk:track-changes="false"/>
```

## Form and submissions
[164-Audit-Email.zip](https://github.com/getodk/build/files/7968320/164-Audit-Email.zip)
The attached ZIP is the export of two test submissions to the (also included) XForm. I've edited out my (verified correct) coordinates Ith `xxx` where recorded by the audit log. I can also see my email which I've set in the Collect metadata as "noreply@email.org" - looks like a default, but that was actually me. The top level audit log contains the audit for both submissions, the media/audit.csv contains only the last form's audit log.

From these test submissions I conclude that the email and audit controls work and generate a valid XForm. I didn't test any edge cases or other forms yet.
