### PR TITLE
improve: dedicated error for no form selected in my forms

### DIFF
--- a/public/javascripts/data-ui.js
+++ b/public/javascripts/data-ui.js
@@ -24,16 +24,16 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
             },
             error: function(request, status, error)
             {
-                console.log(error);
+                console.log("Could not open the form, error: " + error);
                 
                 if (error == "Not Found") 
                 {
                     var msg = '<p>Error: No form selected.</p>'
-                }
-                else{
+                } else  
+                {
                     var msg = '<p>Could not open the form. See browser console log for a detailed error message.</p>';
                 }
-                
+
                 $('.openDialog .errorMessage')
                     .empty()
                     .append(msg)

--- a/public/javascripts/data-ui.js
+++ b/public/javascripts/data-ui.js
@@ -24,9 +24,19 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
             },
             error: function(request, status, error)
             {
+                console.log(error);
+                
+                if (error == "Not Found") 
+                {
+                    var msg = '<p>Error: No form selected.</p>'
+                }
+                else{
+                    var msg = '<p>Could not open the form. See browser console log for a detailed error message.</p>';
+                    console.log(error);
+                }
                 $('.openDialog .errorMessage')
                     .empty()
-                    .append('<p>Could not open the form. Please try again in a moment.</p>')
+                    .append(msg)
                     .slideDown();
             }
         });

--- a/public/javascripts/data-ui.js
+++ b/public/javascripts/data-ui.js
@@ -32,8 +32,8 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
                 }
                 else{
                     var msg = '<p>Could not open the form. See browser console log for a detailed error message.</p>';
-                    console.log(error);
                 }
+                
                 $('.openDialog .errorMessage')
                     .empty()
                     .append(msg)


### PR DESCRIPTION
A tiny PR to emit a custom error message when a user forgot to select a form to open.

![image](https://user-images.githubusercontent.com/762815/151749534-ff282427-f4ed-48d2-a0d4-880d5528b818.png)

Other errors at form open output the error to the browser console and advise the user. This might be more informative than the "something's wrong" type generic error, or it might leak sensitive information in cases I haven't thought about - in the latter case we might not want to log the error to the browser console.