### PR TITLE
new: Support Audit log

### DIFF
--- a/public/javascripts/data.js
+++ b/public/javascripts/data.js
@@ -995,31 +995,36 @@ var dataNS = odkmaker.namespace.load('odkmaker.data');
                 }
             };
 
-            if (internal.metadata.location_priority != undefined && internal.metadata.location_priority != 'off') {
+            if (internal.metadata.track_changes != undefined) 
+            {
+                binding.attrs['odk:track-changes'] = internal.metadata.track_changes;
+                var track_changes_status = (internal.metadata.track_changes == 'true') ? 'enabled' : 'not enabled';
+                console.log('Track changes audit ' + track_changes_status + '.')
+            } else {
+                console.log('Track changes audit not enabled.');
+            };
+
+            if (internal.metadata.location_priority != undefined && internal.metadata.location_priority != 'off') 
+            {
                 /* Enable location audit with sane defaults if missing */
                 binding.attrs['odk:location-priority'] = internal.metadata.location_priority;
-                if (internal.metadata.location_min_interval != undefined) {
+                if (internal.metadata.location_min_interval != undefined && internal.metadata.location_min_interval != '') 
+                {
                     binding.attrs['odk:location-min-interval'] = internal.metadata.location_min_interval;
                 } else {
                     binding.attrs['odk:location-min-interval'] = '20';
-                    console.log("Location min interval not specified, defaulting to 20 seconds.");
+                    console.log('Location min interval not specified, defaulting to 20 seconds.');
                 };
-                if (internal.metadata.location_max_age != undefined) {
+                if (internal.metadata.location_max_age != undefined && internal.metadata.location_max_age != '') 
+                {
                     binding.attrs['odk:location-max-age'] = internal.metadata.location_max_age;
                 } else {
                     binding.attrs['odk:location-max-age'] = '60';
-                    console.log("Location max age not specified, defaulting to 60 seconds.");
+                    console.log('Location max age not specified, defaulting to 60 seconds.');
                 };
-                console.log("Location audit enabled.");
+                console.log('Location audit enabled.');
             } else {
-                console.log("Location audit not enabled.");
-            };
-
-            if (internal.metadata.track_changes != undefined) {
-                binding.attrs['odk:track-changes'] = internal.metadata.track_changes;
-                console.log("Track changes audit enabled.");
-            } else {
-                console.log("Track changes audit not enabled.");
+                console.log('Location audit not enabled.');
             };
 
             model.children.push(binding);

--- a/public/stylesheets/styles.css
+++ b/public/stylesheets/styles.css
@@ -1466,13 +1466,13 @@ body > .control.last .controlFlowArrow,
 .formPropertiesDialog input,
 .formPropertiesDialog select
 {
-    margin-left: 10em;
-    width: calc(100% - 10em);
+    margin-left: 15em;
+    width: calc(100% - 15em);
 }
 .formPropertiesDialog p
 {
     font-size: 1.1em;
-    padding-left: 10em;
+    padding-left: 15em;
 }
 
 .errorMessage p

--- a/server/views/index.erb
+++ b/server/views/index.erb
@@ -296,7 +296,7 @@
       </div>
     </div>
 
-    <div class="modal narrowModal formPropertiesDialog">
+    <div class="modal formPropertiesDialog">
       <h3>Form Properties</h3>
       <div class="modalContents">
         <form>
@@ -332,6 +332,34 @@
             <option value="false">Never</option>
           </select>
           <p>Override or follow the ODK Collect form management setting "Delete after send".</p>
+
+          <label for="formProperties_track_changes">Track form changes</label>
+          <select id="formProperties_track_changes" name="track_changes">
+            <option value="false">No</option>
+            <option value="true">Yes</option>
+          </select>
+          <p>Whether to track changes to the form made any time before submission.</p>
+
+          <label for="formProperties_location_priority">Track device location</label>
+          <select id="formProperties_location_priority" name="location_priority">
+            <option value="off">Off</option>
+            <option value="no-power">No power</option>
+            <option value="low-power">Low power</option>
+            <option value="balanced">Balanced</option>
+            <option value="high-accuracy">High accuracy</option>
+          </select>
+          <p>Whether to track the location of the device while filling the form. 
+          Using "balanced" will capture the location at least at specified intervals while preserving power. 
+          Learn <a href="https://developers.google.com/android/reference/com/google/android/gms/location/LocationRequest" 
+          target="_" rel="nofollow">here</a> about available options to balance accuracy with power consumption.</p>        
+
+          <label for="formProperties_location_min_interval">Capture location every</label>
+          <input type="number" id="formProperties_location_min_interval" name="location_min_interval" value="20"/>
+          <p>If device location is tracked, it will be attempted to be captured at least every this many seconds.</p>  
+
+          <label for="formProperties_location_max_age">Location valid for</label>
+          <input type="number" id="formProperties_location_max_age" name="location_max_age" value="60"/>
+          <p>If device location is tracked, a captured location will be considered representative of the device location for this many seconds.</p>
         </form>
       </div>
       <div class="modalButtonContainer">


### PR DESCRIPTION
* Closes #164
* Closes #284 - this PR presents audit options in a more logical manner to the user. 
* Audit settings are form properties like autosend/delete. Audit settings are form-wide, once per form, have no defined position in the form (unlike questions where position matters), and must be unique (once or nonce per form, again unlike questions). All of this speaks against a drag and drop question like metadata, and for form properties.
* Code comments and console logging for clarity, if a bit noisy. Note: I've swapped the order of logging halfway through screenshotting the walk-through - track changes logs before location audit.
* Form props modal widened to fit four new fields - could use a designer's eye to verify spacing / margins.

## Impressions
Screen shots and walk-through below.
<details>
### New form defaults
A new form shows "all off" defaults.
![image](https://user-images.githubusercontent.com/762815/152719181-8081c8a1-d782-437c-aab2-52d525f15edc.png)

### New form, track changes
Enable track changes adds `data/meta/audit` and `<bind nodeset="data/meta/audit" type="binary" odk:track-changes="true"/>`.
```
<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:orx="http://openrosa.org/xforms" xmlns:odk="http://www.opendatakit.org/xforms">
  <h:head>
    <h:title>Untitled Form</h:title>
    <model>
      <instance>
        <data id="Untitled-Form" version="1644203944">
          <meta>
            <instanceID/>
            <audit/>
          </meta>
        </data>
      </instance>
      <itext>
        <translation lang="English">
        </translation>
      </itext>
      <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" jr:preload="uid"/>
      <bind nodeset="data/meta/audit" type="binary" odk:track-changes="true"/>
    </model>
  </h:head>
  <h:body>
  </h:body>
</h:html>
```
Console log:
![image](https://user-images.githubusercontent.com/762815/152719320-7f582f11-14d3-4c43-b990-b7753ea54fcc.png)

### New form, track changes, track location
Setting the "Track device location" to e.g. "Balanced", retaining the defaults for min interval and max age:
![image](https://user-images.githubusercontent.com/762815/152719481-ab4de0a5-63b2-4639-b33f-8eb4ed3aa4b4.png)

This adds the three location audit attributes to the bind node `<bind nodeset="data/meta/audit" type="binary" odk:location-priority="balanced" odk:location-min-interval="20" odk:location-max-age="60" odk:track-changes="true"/>`:
```
<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:orx="http://openrosa.org/xforms" xmlns:odk="http://www.opendatakit.org/xforms">
  <h:head>
    <h:title>Untitled Form</h:title>
    <model>
      <instance>
        <data id="Untitled-Form" version="1644204193">
          <meta>
            <instanceID/>
            <audit/>
          </meta>
        </data>
      </instance>
      <itext>
        <translation lang="English">
        </translation>
      </itext>
      <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" jr:preload="uid"/>
      <bind nodeset="data/meta/audit" type="binary" odk:location-priority="balanced" odk:location-min-interval="20" odk:location-max-age="60" odk:track-changes="true"/>
    </model>
  </h:head>
  <h:body>
  </h:body>
</h:html>
```
Console log:
![image](https://user-images.githubusercontent.com/762815/152719673-4b81f4af-db2d-4892-adcf-1b8346d68a18.png)

### New form, disable track changes, keep location audit
Setting "Track changes" to "No" and changing "Track device location" to "High accuracy":
![image](https://user-images.githubusercontent.com/762815/152719782-d23f7f1b-9f3c-48b8-88a4-b731235cd9b0.png)

The `data/meta/audit` node is still there, and the bind node now shows `track changes` as `false`
```
<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:jr="http://openrosa.org/javarosa" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:orx="http://openrosa.org/xforms" xmlns:odk="http://www.opendatakit.org/xforms">
  <h:head>
    <h:title>Untitled Form</h:title>
    <model>
      <instance>
        <data id="Untitled-Form" version="1644204368">
          <meta>
            <instanceID/>
            <audit/>
          </meta>
        </data>
      </instance>
      <itext>
        <translation lang="English">
        </translation>
      </itext>
      <bind nodeset="/data/meta/instanceID" type="string" readonly="true()" jr:preload="uid"/>
      <bind nodeset="data/meta/audit" type="binary" odk:location-priority="high-accuracy" odk:location-min-interval="20" odk:location-max-age="60" odk:track-changes="false"/>
    </model>
  </h:head>
  <h:body>
  </h:body>
</h:html>
```
Console log:
![image](https://user-images.githubusercontent.com/762815/152720512-feea5fdf-5634-4b9b-a1a7-7eda122b649d.png)

### Existing form
In an existing form, the new form properties are not set, defaulting to "all off".
![image](https://user-images.githubusercontent.com/762815/152720619-eb7d8442-6afd-485a-884e-162bf2a01980.png)

Exporting to XML creates neither a `data/meta/audit` node nor a bind node.

### Existing form plus track changes
Exported XML now has `data/meta/audit` node and `<bind nodeset="data/meta/audit" type="binary" odk:track-changes="true"/>`.

### Existing form plus track changes plus location audit
Location min interval and max age are kept empty.
![image](https://user-images.githubusercontent.com/762815/152720928-4e3b3f03-05b4-4511-8d82-52437fa17b04.png)

Exported XML has `data/meta/audit` node and has expanded `<bind nodeset="data/meta/audit" type="binary" odk:track-changes="true" odk:location-priority="balanced" odk:location-min-interval="20" odk:location-max-age="60"/>` with sensible defaults.

The console explains what happened:
![image](https://user-images.githubusercontent.com/762815/152721456-58d528cd-2122-47bc-b246-f6e301e25aec.png)

### Existing form with location audit minus track changes
Setting "Track changes" to "No" works as expected: 
Exported XML has `data/meta/audit` node and has `<bind nodeset="data/meta/audit" type="binary" odk:track-changes="false" odk:location-priority="balanced" odk:location-min-interval="20" odk:location-max-age="60"/>`.

We still haven't bothered with min/max attributes and still get the explanation about the defaults.
![image](https://user-images.githubusercontent.com/762815/152721668-f9ffa89e-d6dc-4510-948b-13b210471019.png)

### Saving a new form with audit
A new form with audit properties set and saved does remember these settings when loaded again.
</details>