### PR TITLE
Fix #307: Init inputSelectMany with empty cascade option

### DIFF
--- a/public/javascripts/control.js
+++ b/public/javascripts/control.js
@@ -750,7 +750,7 @@
                             'If you have many options or reuse options frequently, use Bulk Edit.',
                             'The Underlying Value is the value saved to the exported data.' ],
                         validation: [ 'underlyingRequired', 'underlyingLegalChars', 'underlyingLength', 'hasOptions' ],
-                        value: [{ text: {}, val: 'untitled' }],
+                        value: [{ text: {}, cascade: [], val: 'untitled' }],
                         summary: false },
           other:      { name: 'Follow-up Question',
                         type: 'otherEditor',


### PR DESCRIPTION
* control.js: Do what inputSelectOne does and initiate an empty cascade option.
* This will not fix existing forms.
* Existing forms need to delete the first option of SelectMultiple, then rebuild the options.

## Testing
* Use `.odkbuild` save file from original issue.
* Drop the SelectMultiple question.
* Create a new SelectMultiple question and add two more options.
* Note: cascading SelectOnes still have the original issue and will not work as expected - underlying values do not match.
* Export to XLSX - works.
* Export to XML - works.
* [SchoolCensusMinimalFix.zip](https://github.com/getodk/build/files/8697843/SchoolCensusMinimalFix.zip): working form as .odkbuild, XML, XLSX.
* See last comment #307 for the same form but fixed with opinionated suggestions
