### PR TITLE
Use specific domain to increase deliverability

### DIFF
--- a/server/odkbuild_server.rb
+++ b/server/odkbuild_server.rb
@@ -189,7 +189,7 @@ class OdkBuild < Sinatra::Application
     new_password = user.reset_password!
     user.save
 
-    (Pony.mail :to => user.email, :from => 'support@getodk.org',
+    (Pony.mail :to => user.email, :from => 'ODK Build <no-reply@build.getodk.org>',
                :subject => 'Your new ODK Build password.',
                :body => "Your ODK Build password has been reset. The new password is #{new_password}.\n\nThanks,\nThe ODK Build Team")
 


### PR DESCRIPTION
Build was not delivering password resets. Probably because it's sending email from an IP with no DKIM, etc. I've changed the infrastructure to use AWS SES to send emails.

Build's code relies on [Pony](https://github.com/benprew/pony) which relies on sendmail, so after I verified the domain on SES, I followed [send email through SES with sendmail](https://web.archive.org/web/20221111144034/https://docs.aws.amazon.com/ses/latest/dg/send-email-sendmail.html) to configure the server.

I needed to do a hot fix, so this code is already running in production...