### PR TITLE
Replace Fathom with CloudFlare

### DIFF
--- a/server/views/index.erb
+++ b/server/views/index.erb
@@ -8,7 +8,6 @@
     <link rel="icon" href="/images/favicon.ico">
     <link rel="stylesheet" type="text/css" href="/stylesheets/styles.css"/>
     <link rel="stylesheet" type="text/css" href="/stylesheets/jquery-ui.min.css"/>
-  <script src="https://helper.getodk.org/script.js" data-site="PBSTMJFG" defer></script>
   <!-- Used to toggle additional form properties, eg. audit attributes -->
   <script>
     function showDiv(divId, element, hide_if_value)
@@ -633,5 +632,6 @@
       </div>
 
     </div>
+    <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "11c044ed60754ca49baecf9db53a9f04"}'></script>
   </body>
 </html>


### PR DESCRIPTION
We've deprecated Fathom in favor of CloudFlare across the tools.

This code is already in prod.